### PR TITLE
[Locus] Implement Swagger/OpenAPI With Basic Auth and Fail-Fast Env Validation in API

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,8 +25,10 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^5.0.1",
+    "@nestjs/swagger": "^11.2.6",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
+    "express-basic-auth": "^1.2.1",
     "helmet": "^8.1.0",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
@@ -35,6 +37,7 @@
     "reflect-metadata": "^0.2.2",
     "resend": "^6.8.0",
     "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.20",
     "zod": "^4.3.6"
   },

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -21,6 +21,7 @@ import {
   UseGuards,
   UsePipes,
 } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { Throttle } from "@nestjs/throttler";
 import { Request, Response } from "express";
 import { ZodValidationPipe } from "@/common/pipes";
@@ -32,6 +33,7 @@ import { extractIp, GoogleAuthGuard } from "./guards";
 import { GoogleUser } from "./interfaces/google-user.interface";
 import { IpReputationService } from "./services";
 
+@ApiTags("Auth")
 @Controller("auth")
 export class AuthController {
   constructor(
@@ -41,6 +43,8 @@ export class AuthController {
   ) {}
 
   @Get("me")
+  @ApiOperation({ summary: "Get current authenticated user profile" })
+  @ApiOkResponse({ description: "Current authenticated user profile." })
   async getProfile(@CurrentUser() authUser: AuthenticatedUser) {
     // This endpoint only works for JWT-authenticated users
     if (!isJwtUser(authUser)) {
@@ -85,6 +89,8 @@ export class AuthController {
   }
 
   @Get("api-key")
+  @ApiOperation({ summary: "Get current API key authentication context" })
+  @ApiOkResponse({ description: "Current API key context." })
   async getApiKeyInfo(@CurrentUser() authUser: AuthenticatedUser) {
     // This endpoint only works for API Key authenticated users
     if (isJwtUser(authUser)) {

--- a/apps/api/src/ci/ci.controller.ts
+++ b/apps/api/src/ci/ci.controller.ts
@@ -4,16 +4,20 @@ import {
   ReportCiResultSchema,
 } from "@locusai/shared";
 import { Body, Controller, Param, Post } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CurrentUser, Member } from "@/auth/decorators";
 import { ZodValidationPipe } from "@/common/pipes";
 import { CiService } from "./ci.service";
 
+@ApiTags("CI")
 @Controller("ci")
 export class CiController {
   constructor(private readonly ciService: CiService) {}
 
   @Post("report/:workspaceId")
   @Member()
+  @ApiOperation({ summary: "Report CI run result for a workspace" })
+  @ApiOkResponse({ description: "CI result reported successfully." })
   async report(
     @CurrentUser() user: AuthenticatedUser,
     @Param("workspaceId") workspaceId: string,

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -2,35 +2,63 @@ import { z } from "zod";
 
 const INSECURE_JWT_SECRETS = ["secret", "changeme", "jwt_secret"];
 
-export const ConfigSchema = z.object({
-  NODE_ENV: z
-    .enum(["development", "production", "test"])
-    .default("development"),
-  PORT: z.coerce.number().default(8000),
-  DATABASE_URL: z.string(),
-  DATABASE_SYNC: z.enum(["true", "false"]).default("false"),
-  JWT_SECRET: z.string().min(32),
-  JWT_EXPIRES_IN: z.union([z.string(), z.number()]).default("7d"),
-  RESEND_API_KEY: z.string().optional(),
-  OTP_EXPIRES_IN_MINUTES: z.coerce.number().default(10),
-  CORS_ORIGIN: z.string().default("*"),
-  GOOGLE_GENERATIVE_AI_API_KEY: z.string().optional(),
-  GOOGLE_CLIENT_ID: z.string().optional(),
-  GOOGLE_CLIENT_SECRET: z.string().optional(),
-  GOOGLE_CALLBACK_URL: z.string().optional(),
-  FRONTEND_URL: z.string().default("http://localhost:3000"),
-  // Rate limiting
-  THROTTLE_TTL: z.coerce.number().default(60),
-  THROTTLE_LIMIT: z.coerce.number().default(100),
+export const ConfigSchema = z
+  .object({
+    NODE_ENV: z
+      .enum(["development", "production", "test"])
+      .default("development"),
+    PORT: z.coerce.number().default(8000),
+    DATABASE_URL: z.string(),
+    DATABASE_SYNC: z.enum(["true", "false"]).default("false"),
+    JWT_SECRET: z.string().min(32),
+    JWT_EXPIRES_IN: z.union([z.string(), z.number()]).default("7d"),
+    RESEND_API_KEY: z.string().optional(),
+    OTP_EXPIRES_IN_MINUTES: z.coerce.number().default(10),
+    CORS_ORIGIN: z.string().default("*"),
+    GOOGLE_GENERATIVE_AI_API_KEY: z.string().optional(),
+    GOOGLE_CLIENT_ID: z.string().optional(),
+    GOOGLE_CLIENT_SECRET: z.string().optional(),
+    GOOGLE_CALLBACK_URL: z.string().optional(),
+    FRONTEND_URL: z.string().default("http://localhost:3000"),
+    // Rate limiting
+    THROTTLE_TTL: z.coerce.number().default(60),
+    THROTTLE_LIMIT: z.coerce.number().default(100),
 
-  // Account lockout
-  LOCKOUT_MAX_ATTEMPTS: z.coerce.number().default(5),
-  LOCKOUT_WINDOW_MINUTES: z.coerce.number().default(15),
-  LOCKOUT_DURATION_MINUTES: z.coerce.number().default(30),
+    // Account lockout
+    LOCKOUT_MAX_ATTEMPTS: z.coerce.number().default(5),
+    LOCKOUT_WINDOW_MINUTES: z.coerce.number().default(15),
+    LOCKOUT_DURATION_MINUTES: z.coerce.number().default(30),
 
-  // OTP security
-  OTP_MAX_ATTEMPTS: z.coerce.number().default(5),
-});
+    // OTP security
+    OTP_MAX_ATTEMPTS: z.coerce.number().default(5),
+    // Swagger docs
+    SWAGGER_DOCS_ENABLED: z.enum(["true", "false"]).default("false"),
+    SWAGGER_DOCS_USERNAME: z.string().optional(),
+    SWAGGER_DOCS_PASSWORD: z.string().optional(),
+  })
+  .superRefine((config, ctx) => {
+    if (config.SWAGGER_DOCS_ENABLED !== "true") {
+      return;
+    }
+
+    if (!config.SWAGGER_DOCS_USERNAME?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["SWAGGER_DOCS_USERNAME"],
+        message:
+          "SWAGGER_DOCS_USERNAME is required when SWAGGER_DOCS_ENABLED=true",
+      });
+    }
+
+    if (!config.SWAGGER_DOCS_PASSWORD?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["SWAGGER_DOCS_PASSWORD"],
+        message:
+          "SWAGGER_DOCS_PASSWORD is required when SWAGGER_DOCS_ENABLED=true",
+      });
+    }
+  });
 
 export type Config = z.infer<typeof ConfigSchema>;
 
@@ -74,11 +102,14 @@ export default () => {
   const result = ConfigSchema.safeParse(process.env);
 
   if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => `${issue.path.join(".") || "root"}: ${issue.message}`)
+      .join("; ");
     console.error(
       "❌ Invalid environment variables:",
       z.treeifyError(result.error)
     );
-    throw new Error("Invalid api configuration");
+    throw new Error(`Invalid api configuration: ${issues}`);
   }
 
   validateSecurityConfig(result.data);

--- a/apps/api/src/docs/doc-groups.controller.ts
+++ b/apps/api/src/docs/doc-groups.controller.ts
@@ -15,16 +15,20 @@ import {
   Patch,
   Post,
 } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { AnyMember, MemberAdmin } from "@/auth/decorators";
 import { ZodValidationPipe } from "@/common/pipes";
 import { DocGroupsService } from "./doc-groups.service";
 
+@ApiTags("Doc Groups")
 @Controller("workspaces/:workspaceId/doc-groups")
 export class DocGroupsController {
   constructor(private readonly docGroupsService: DocGroupsService) {}
 
   @Get()
   @AnyMember()
+  @ApiOperation({ summary: "List doc groups by workspace" })
+  @ApiOkResponse({ description: "Doc groups returned successfully." })
   async list(
     @Param("workspaceId") workspaceId: string
   ): Promise<DocGroupsResponse> {

--- a/apps/api/src/docs/docs.controller.ts
+++ b/apps/api/src/docs/docs.controller.ts
@@ -15,10 +15,12 @@ import {
   Post,
   Put,
 } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { AnyMember, Member, MemberAdmin } from "@/auth/decorators";
 import { ZodValidationPipe } from "@/common/pipes";
 import { DocsService } from "./docs.service";
 
+@ApiTags("Docs")
 @Controller("workspaces/:workspaceId/docs")
 export class DocsController {
   constructor(private readonly docsService: DocsService) {}
@@ -38,6 +40,8 @@ export class DocsController {
 
   @Get()
   @AnyMember()
+  @ApiOperation({ summary: "List docs by workspace" })
+  @ApiOkResponse({ description: "Docs returned successfully." })
   async list(@Param("workspaceId") workspaceId: string): Promise<DocsResponse> {
     const docs = await this.docsService.findByWorkspace(workspaceId);
     return { docs } as unknown as DocsResponse;

--- a/apps/api/src/health/dto/health-check-response.dto.ts
+++ b/apps/api/src/health/dto/health-check-response.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+class HealthServicesResponseDto {
+  @ApiProperty({
+    description: "Database connectivity state.",
+    example: "up",
+    enum: ["up", "down"],
+  })
+  database!: "up" | "down";
+}
+
+export class HealthCheckResponseDto {
+  @ApiProperty({
+    description: "Overall service status derived from dependency health.",
+    example: "ok",
+    enum: ["ok", "error"],
+  })
+  status!: "ok" | "error";
+
+  @ApiProperty({
+    description: "Health status for individual backend dependencies.",
+    type: HealthServicesResponseDto,
+  })
+  services!: HealthServicesResponseDto;
+}

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,17 +1,22 @@
 import { Controller, Get } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { SkipThrottle } from "@nestjs/throttler";
 import { DataSource } from "typeorm";
 import { Public } from "../auth/decorators/public.decorator";
+import { HealthCheckResponseDto } from "./dto/health-check-response.dto";
 
 @SkipThrottle()
+@ApiTags("Health")
 @Controller("health")
 export class HealthController {
   constructor(private dataSource: DataSource) {}
 
   @Public()
   @Get()
-  async check() {
-    let dbStatus = "up";
+  @ApiOperation({ summary: "Service health check" })
+  @ApiOkResponse({ type: HealthCheckResponseDto })
+  async check(): Promise<HealthCheckResponseDto> {
+    let dbStatus: "up" | "down" = "up";
     try {
       await this.dataSource.query("SELECT 1");
     } catch {

--- a/apps/api/src/invitations/invitations.controller.ts
+++ b/apps/api/src/invitations/invitations.controller.ts
@@ -11,6 +11,7 @@ import {
   OrgIdParamSchema,
 } from "@locusai/shared";
 import { Body, Controller, Delete, Get, Param, Post } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { MemberAdmin } from "@/auth/decorators/membership-roles.decorator";
 import { Public } from "@/auth/decorators/public.decorator";
 import { CurrentUser } from "@/auth/decorators/user.decorator";
@@ -18,12 +19,15 @@ import { ZodValidationPipe } from "@/common/pipes/zod-validation.pipe";
 import { User } from "@/entities";
 import { InvitationsService } from "./invitations.service";
 
+@ApiTags("Invitations")
 @Controller()
 export class InvitationsController {
   constructor(private readonly invitationsService: InvitationsService) {}
 
   @Post("org/:orgId/invitations")
   @MemberAdmin()
+  @ApiOperation({ summary: "Create an organization invitation" })
+  @ApiOkResponse({ description: "Invitation created successfully." })
   async create(
     @Param(new ZodValidationPipe(OrgIdParamSchema)) params: OrgIdParam,
     @CurrentUser() user: User,
@@ -40,6 +44,8 @@ export class InvitationsController {
 
   @Get("org/:orgId/invitations")
   @MemberAdmin()
+  @ApiOperation({ summary: "List organization invitations" })
+  @ApiOkResponse({ description: "Invitations returned successfully." })
   async list(
     @Param(new ZodValidationPipe(OrgIdParamSchema)) params: OrgIdParam
   ): Promise<InvitationsResponse> {
@@ -49,6 +55,8 @@ export class InvitationsController {
 
   @Public()
   @Get("invitations/verify/:token")
+  @ApiOperation({ summary: "Verify invitation token" })
+  @ApiOkResponse({ description: "Invitation returned successfully." })
   async verify(
     @Param(new ZodValidationPipe(InvitationVerifyParamSchema))
     params: InvitationVerifyParam

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,6 +5,7 @@ import { AppModule } from "./app.module";
 import { AppLogger } from "./common/logger";
 import { requestIdMiddleware } from "./common/middleware/request-id.middleware";
 import { TypedConfigService } from "./config/config.service";
+import { setupSwaggerDocs } from "./swagger/swagger-docs";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -71,6 +72,12 @@ async function bootstrap() {
       "X-Request-ID",
     ],
     maxAge: 86400,
+  });
+
+  setupSwaggerDocs(app, {
+    enabled: configService.get("SWAGGER_DOCS_ENABLED") === "true",
+    username: configService.get("SWAGGER_DOCS_USERNAME") ?? "",
+    password: configService.get("SWAGGER_DOCS_PASSWORD") ?? "",
   });
 
   const port = configService.get("PORT");

--- a/apps/api/src/organizations/organizations.controller.ts
+++ b/apps/api/src/organizations/organizations.controller.ts
@@ -9,6 +9,7 @@ import {
   OrgIdParamSchema,
 } from "@locusai/shared";
 import { Body, Controller, Delete, Get, Param, Post } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { z } from "zod";
 import {
   CurrentUser,
@@ -20,11 +21,14 @@ import { ZodValidationPipe } from "@/common/pipes";
 import { User } from "@/entities";
 import { OrganizationsService } from "./organizations.service";
 
+@ApiTags("Organizations")
 @Controller("organizations")
 export class OrganizationsController {
   constructor(private readonly organizationsService: OrganizationsService) {}
 
   @Get()
+  @ApiOperation({ summary: "List organizations for current user" })
+  @ApiOkResponse({ description: "Organizations returned successfully." })
   async list(@CurrentUser() user: User): Promise<OrganizationsResponse> {
     const organizations = await this.organizationsService.findByUser(user.id);
     return { organizations };
@@ -32,6 +36,8 @@ export class OrganizationsController {
 
   @Get(":orgId")
   @Member()
+  @ApiOperation({ summary: "Get organization by ID" })
+  @ApiOkResponse({ description: "Organization returned successfully." })
   async getById(
     @Param(new ZodValidationPipe(OrgIdParamSchema)) params: OrgIdParam
   ): Promise<OrganizationResponse> {

--- a/apps/api/src/sprints/sprints.controller.ts
+++ b/apps/api/src/sprints/sprints.controller.ts
@@ -15,11 +15,13 @@ import {
   Patch,
   Post,
 } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CurrentUserId, Member } from "@/auth/decorators";
 import { ZodValidationPipe } from "@/common/pipes";
 import { WorkspacesService } from "@/workspaces/workspaces.service";
 import { SprintsService } from "./sprints.service";
 
+@ApiTags("Sprints")
 @Controller("workspaces/:workspaceId/sprints")
 export class SprintsController {
   constructor(
@@ -38,6 +40,8 @@ export class SprintsController {
 
   @Get()
   @Member()
+  @ApiOperation({ summary: "List workspace sprints" })
+  @ApiOkResponse({ description: "Sprints returned successfully." })
   async list(
     @Param("workspaceId") workspaceId: string
   ): Promise<SprintsResponse> {
@@ -48,6 +52,8 @@ export class SprintsController {
 
   @Get("active")
   @Member()
+  @ApiOperation({ summary: "Get active workspace sprint" })
+  @ApiOkResponse({ description: "Active sprint returned successfully." })
   async getActive(
     @Param("workspaceId") workspaceId: string
   ): Promise<SprintResponse> {

--- a/apps/api/src/swagger/swagger-docs.ts
+++ b/apps/api/src/swagger/swagger-docs.ts
@@ -1,0 +1,49 @@
+import type { INestApplication } from "@nestjs/common";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import basicAuth from "express-basic-auth";
+
+export const SWAGGER_UI_PATH = "/api/docs";
+export const SWAGGER_JSON_PATH = "/api/docs-json";
+
+type SwaggerDocsConfig = {
+  enabled: boolean;
+  username: string;
+  password: string;
+};
+
+export function setupSwaggerDocs(
+  app: INestApplication,
+  config: SwaggerDocsConfig
+) {
+  if (!config.enabled) {
+    return null;
+  }
+
+  const expressApp = app.getHttpAdapter().getInstance();
+  const docsAuthMiddleware = basicAuth({
+    users: {
+      [config.username]: config.password,
+    },
+    challenge: true,
+    unauthorizedResponse: () => "Unauthorized",
+  });
+
+  expressApp.use(SWAGGER_UI_PATH, docsAuthMiddleware);
+  expressApp.use(SWAGGER_JSON_PATH, docsAuthMiddleware);
+
+  const document = SwaggerModule.createDocument(
+    app,
+    new DocumentBuilder()
+      .setTitle("Locus API")
+      .setDescription("Locus backend API documentation")
+      .setVersion("1.0.0")
+      .addBearerAuth()
+      .build()
+  );
+
+  SwaggerModule.setup("api/docs", app, document, {
+    jsonDocumentUrl: "api/docs-json",
+  });
+
+  return document;
+}

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -20,12 +20,19 @@ import {
   Patch,
   Post,
 } from "@nestjs/common";
+import {
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from "@nestjs/swagger";
 import { CurrentUserId, Member, MemberAdmin } from "@/auth/decorators";
 import { ZodValidationPipe } from "@/common/pipes";
 import { Task } from "@/entities";
 import { WorkspacesService } from "@/workspaces/workspaces.service";
 import { TasksService } from "./tasks.service";
 
+@ApiTags("Tasks")
 @Controller("workspaces/:workspaceId/tasks")
 export class TasksController {
   constructor(
@@ -36,6 +43,8 @@ export class TasksController {
 
   @Get()
   @Member()
+  @ApiOperation({ summary: "List tasks in a workspace" })
+  @ApiOkResponse({ description: "Tasks returned successfully." })
   async list(
     @Param("workspaceId") workspaceId: string
   ): Promise<TasksResponse> {
@@ -60,6 +69,8 @@ export class TasksController {
 
   @Get(":taskId")
   @Member()
+  @ApiOperation({ summary: "Get task by ID" })
+  @ApiOkResponse({ description: "Task returned successfully." })
   async getById(@Param("taskId") taskId: string): Promise<TaskResponse> {
     const task = await this.tasksService.findById(taskId);
     return { task: this.taskToTaskResponse(task) };
@@ -67,6 +78,8 @@ export class TasksController {
 
   @Post()
   @Member()
+  @ApiOperation({ summary: "Create task in a workspace" })
+  @ApiCreatedResponse({ description: "Task created successfully." })
   async create(
     @CurrentUserId() userId: string | null,
     @Param("workspaceId") workspaceId: string,

--- a/apps/api/src/workspaces/workspaces.controller.ts
+++ b/apps/api/src/workspaces/workspaces.controller.ts
@@ -25,6 +25,7 @@ import {
   Put,
   Query,
 } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { z } from "zod";
 import { CurrentUser, Member, MemberAdmin } from "@/auth/decorators";
 import { ZodValidationPipe } from "@/common/pipes";
@@ -33,6 +34,7 @@ import { User } from "@/entities/user.entity";
 import { TasksService } from "@/tasks/tasks.service";
 import { WorkspacesService } from "./workspaces.service";
 
+@ApiTags("Workspaces")
 @Controller("workspaces")
 export class WorkspacesController {
   constructor(
@@ -42,6 +44,8 @@ export class WorkspacesController {
   ) {}
 
   @Get()
+  @ApiOperation({ summary: "List workspaces for current user" })
+  @ApiOkResponse({ description: "Workspaces returned successfully." })
   async listAll(@CurrentUser() user: User) {
     const workspaces = await this.workspacesService.findByUser(user.id);
     return { workspaces };
@@ -90,6 +94,8 @@ export class WorkspacesController {
 
   @Get(":workspaceId")
   @Member()
+  @ApiOperation({ summary: "Get workspace by ID" })
+  @ApiOkResponse({ description: "Workspace returned successfully." })
   async getById(
     @Param(new ZodValidationPipe(WorkspaceIdParamSchema))
     params: WorkspaceIdParam

--- a/apps/api/test/swagger-config-validation.jest.ts
+++ b/apps/api/test/swagger-config-validation.jest.ts
@@ -1,0 +1,35 @@
+import configuration from "@/config/configuration";
+
+describe("Swagger env validation", () => {
+  const envSnapshot = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...envSnapshot };
+    process.env.NODE_ENV = "test";
+    process.env.DATABASE_URL = "postgres://localhost:5432/db";
+    process.env.JWT_SECRET = "a-very-long-secret-that-is-at-least-32-chars";
+    process.env.SWAGGER_DOCS_ENABLED = "true";
+  });
+
+  afterEach(() => {
+    process.env = { ...envSnapshot };
+  });
+
+  it("fails with explicit error when swagger docs username is missing", () => {
+    delete process.env.SWAGGER_DOCS_USERNAME;
+    process.env.SWAGGER_DOCS_PASSWORD = "docs-pass";
+
+    expect(() => configuration()).toThrow(
+      "SWAGGER_DOCS_USERNAME is required when SWAGGER_DOCS_ENABLED=true"
+    );
+  });
+
+  it("fails with explicit error when swagger docs password is empty", () => {
+    process.env.SWAGGER_DOCS_USERNAME = "docs-user";
+    process.env.SWAGGER_DOCS_PASSWORD = "   ";
+
+    expect(() => configuration()).toThrow(
+      "SWAGGER_DOCS_PASSWORD is required when SWAGGER_DOCS_ENABLED=true"
+    );
+  });
+});

--- a/apps/api/test/swagger-docs.e2e.jest.ts
+++ b/apps/api/test/swagger-docs.e2e.jest.ts
@@ -1,0 +1,103 @@
+import "reflect-metadata";
+import { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+import { DataSource } from "typeorm";
+import { HealthController } from "@/health/health.controller";
+import {
+  SWAGGER_JSON_PATH,
+  SWAGGER_UI_PATH,
+  setupSwaggerDocs,
+} from "@/swagger/swagger-docs";
+
+const DOCS_USERNAME = "swagger-user";
+const DOCS_PASSWORD = "swagger-pass";
+
+async function createApp(swaggerEnabled: boolean): Promise<INestApplication> {
+  const moduleRef = await Test.createTestingModule({
+    controllers: [HealthController],
+    providers: [
+      {
+        provide: DataSource,
+        useValue: {
+          query: jest.fn().mockResolvedValue([{ ok: 1 }]),
+        },
+      },
+    ],
+  }).compile();
+
+  const app = moduleRef.createNestApplication();
+  app.setGlobalPrefix("api");
+
+  setupSwaggerDocs(app, {
+    enabled: swaggerEnabled,
+    username: DOCS_USERNAME,
+    password: DOCS_PASSWORD,
+  });
+
+  await app.init();
+  return app;
+}
+
+describe("Swagger docs runtime", () => {
+  let app: INestApplication;
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it("does not expose docs endpoints when disabled", async () => {
+    app = await createApp(false);
+
+    await request(app.getHttpServer()).get(SWAGGER_UI_PATH).expect(404);
+    await request(app.getHttpServer()).get(SWAGGER_JSON_PATH).expect(404);
+  });
+
+  it("returns 401 for docs UI and raw spec without credentials when enabled", async () => {
+    app = await createApp(true);
+
+    await request(app.getHttpServer()).get(SWAGGER_UI_PATH).expect(401);
+    await request(app.getHttpServer()).get(SWAGGER_JSON_PATH).expect(401);
+  });
+
+  it("returns 200 for docs UI and raw spec with valid credentials when enabled", async () => {
+    app = await createApp(true);
+
+    const uiResponse = await request(app.getHttpServer())
+      .get(SWAGGER_UI_PATH)
+      .auth(DOCS_USERNAME, DOCS_PASSWORD)
+      .expect(200);
+    expect(uiResponse.text).toContain("Swagger UI");
+
+    const specResponse = await request(app.getHttpServer())
+      .get(SWAGGER_JSON_PATH)
+      .auth(DOCS_USERNAME, DOCS_PASSWORD)
+      .expect(200);
+    expect(specResponse.body.openapi).toBeDefined();
+  });
+
+  it("generates OpenAPI smoke metadata for key route and schema", async () => {
+    app = await createApp(true);
+
+    const specResponse = await request(app.getHttpServer())
+      .get(SWAGGER_JSON_PATH)
+      .auth(DOCS_USERNAME, DOCS_PASSWORD)
+      .expect(200);
+
+    const spec = specResponse.body;
+    const healthPath = Object.entries(spec.paths || {}).find(([path]) =>
+      /\/health$/.test(path)
+    );
+    expect(healthPath).toBeDefined();
+
+    const operations = Object.values(
+      (healthPath?.[1] as Record<string, { tags?: string[] }>) || {}
+    );
+    expect(
+      operations.some((operation) => operation.tags?.includes("Health"))
+    ).toBe(true);
+    expect(spec.components?.schemas?.HealthCheckResponseDto).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Task: Implement Swagger/OpenAPI With Basic Auth and Fail-Fast Env Validation in API

Implement all runtime Swagger behavior in one backend branch so Swagger wiring is owned by a single task. In `apps/api/package.json`, add the Swagger and HTTP basic auth dependencies required by the current Nest runtime (reuse existing package/version conventions in the repo). In `apps/api/src/main.ts`, add bootstrap logic that only enables docs when `SWAGGER_DOCS_ENABLED=true`: generate the OpenAPI document, expose Swagger UI at `/api/docs`, and expose the raw spec endpoint (e.g., `/api/docs-json` or current project convention). Apply HTTP Basic auth to both the UI route and raw spec route using `SWAGGER_DOCS_USERNAME` and `SWAGGER_DOCS_PASSWORD`; ensure unauthorized requests return 401 and enabled+authorized requests succeed. Extend the existing env validation path in `apps/api/src/config/*` (or the active env validation module used at startup) so startup fails with an explicit validation error when docs are enabled but username/password are missing or empty; keep docs fully unexposed when disabled. Audit `apps/api/src/**/*.controller.ts` and related DTOs and add missing Nest Swagger decorators only where metadata is incomplete (tags, operation/response annotations, DTO schema properties) to improve OpenAPI completeness without changing endpoint behavior. Add automated tests under `apps/api/test/**` that validate: docs disabled behavior, unauthorized 401 for docs UI and spec endpoint, authorized 200 for both endpoints, and OpenAPI document generation smoke coverage for key routes/schemas. Keep scope limited to API runtime/config/test files needed for Swagger docs security and discoverability; out of scope are non-docs authentication changes, endpoint business logic refactors, and unrelated feature work.

## Acceptance Criteria
- [ ] With `SWAGGER_DOCS_ENABLED=false`, `/api/docs` and the docs spec endpoint are not exposed (404 or equivalent disabled behavior).
- [ ] With `SWAGGER_DOCS_ENABLED=true`, requests without valid basic-auth credentials receive 401 for both `/api/docs` and the docs spec endpoint.
- [ ] With valid docs credentials, Swagger UI and the docs spec endpoint are accessible (200).
- [ ] Application startup fails with an explicit env validation error when `SWAGGER_DOCS_ENABLED=true` and `SWAGGER_DOCS_USERNAME` or `SWAGGER_DOCS_PASSWORD` is missing/empty.
- [ ] Automated tests in `apps/api/test/**` run in CI and cover disabled mode, unauthorized denial, authorized access, and OpenAPI generation smoke.

## Agent Summary
**Note**
- `bun add/install` is blocked in this sandbox (`tempdir AccessDenied`), so I could not regenerate `bun.lock` here. `apps/api/package.json` is updated correctly; lockfile refresh may be needed in a normal Bun-enabled environment.

---
*Created by Locus Agent `-k701abi`* | Task ID: `e41b0646-ae1b-4e15-b0bd-26e13c88c94e`